### PR TITLE
Switch to DXML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __dummy.html
 __test__*__
 *.lib
 *.exe
+xlsx-test-library
+libxlsx.a

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.dub
+.dub/
+.vscode/
 docs.json
 __dummy.html
 *.o

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Really defines just one useful function: `readSheet(string fileName, int sheet)`
 Build with `dub build`. I would have written it with only the D standard library (Phobos), but std.zip has issues with `expandedData`
 on members of XLSX files returning empty (zero-length) byte arrays. The Dub archive package, on the other hand, works perfectly.
 
+This branch (`dxml`) is, as the name implies, a switch to using [dxml](https://github.com/jmdavis/dxml) for XML parsing, rather than the long-deprecated `std.xml`.
+
 Example usage:
 
 ```
@@ -23,4 +25,4 @@ void main() {
 
 As of version 0.0.4 now properly reads from the Shared String Table for spreadsheets with many oft-repeating strings and/or whenever Excel decides to make use of it.
 
-Tested on Windows, but written purely in D with no external dependencies, so it should run on all platforms D supports.
+Tested on Windows and Linux (x64), but written purely in D with no external dependencies, so it should run on all platforms D supports.

--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,8 @@
 		"Rudolph"
 	],
 	"dependencies": {
-		"archive": "~>0.6.0"
+		"archive": "~>0.6.0",
+		"dxml": "~>0.3.2"
 	},
 	"description": "Simple XLSX file parser.",
 	"copyright": "Copyleft 2017 Rudolph Raab. All wrongs reserved.",

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,6 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"archive": "0.6.0"
+		"archive": "0.6.0",
+		"dxml": "0.3.2"
 	}
 }

--- a/source/xlsx.d
+++ b/source/xlsx.d
@@ -136,6 +136,13 @@ unittest {
     const Sheet result = parseSheetXML(test, null);
     assert(result == testSheet);
 }
+unittest {
+    const string test = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="x14ac" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac"><dimension ref="A1:C6"/><sheetViews><sheetView tabSelected="1" workbookViewId="0"><selection activeCell="A7" sqref="A7"/></sheetView></sheetViews><sheetFormatPr defaultRowHeight="15" x14ac:dyDescent="0.25"/><sheetData><row r="1" spans="1:3" x14ac:dyDescent="0.25"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row><row r="2" spans="1:3" x14ac:dyDescent="0.25"><c r="A2"><v>1</v></c><c r="B2" s="1"><v>6.2</v></c><c r="C2" s="1"/></row><row r="3" spans="1:3" x14ac:dyDescent="0.25"><c r="A3"><v>2</v></c><c r="B3" s="1"><v>3.4</v></c><c r="C3" s="1"/></row><row r="4" spans="1:3" x14ac:dyDescent="0.25"><c r="A4"><v>3</v></c><c r="B4" s="1"><v>87.1</v></c><c r="C4" s="1"/></row><row r="5" spans="1:3" x14ac:dyDescent="0.25"><c r="A5"><v>4</v></c><c r="B5" s="2"><v>83.2</v></c><c r="C5" s="2"/></row><row r="6" spans="1:3" x14ac:dyDescent="0.25"><c r="A6"><v>5</v></c><c r="B6" s="1"><v>3</v></c><c r="C6" s="1"/></row></sheetData><mergeCells count="1"><mergeCell ref="B5:C5"/></mergeCells><pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/></worksheet>`;
+    const Sheet expected = [["Param", "Value", ""], ["1", "6.2", ""], ["2", "3.4", ""], ["3", "87.1", ""], ["4", "83.2", ""], ["5", "3", ""]];
+    const Sheet result = parseSheetXML(test, ["Param", "Value"]);
+    assert(result == expected);
+}
 
 /++
 Gets the numeric (> 1) id of a sheet with a given name.

--- a/source/xlsx.d
+++ b/source/xlsx.d
@@ -107,13 +107,15 @@ Sheet parseSheetXML(string xmlString, string[] sst) {
                 }
                 assert(loc.row >= 0 && loc.column >= 0);
                 range.popFront;
-                range.popFront;
-                assert(range.front.type == EntityType.text);
-                string text = range.front.text;
-                assert(theRow.length > 0);
-                assert(loc.column < theRow.length);
-                if(isref) theRow[loc.column] = sst[parse!int(text)];
-                else theRow[loc.column] = text;
+                if(range.front.type != EntityType.elementEnd) {
+                    range.popFront;
+                    assert(range.front.type == EntityType.text);
+                    string text = range.front.text;
+                    assert(theRow.length > 0);
+                    assert(loc.column < theRow.length);
+                    if(isref) theRow[loc.column] = sst[parse!int(text)];
+                    else theRow[loc.column] = text;
+                }
             }
         }
         else if(range.front.type == EntityType.elementEnd) {

--- a/source/xlsx.d
+++ b/source/xlsx.d
@@ -1,7 +1,9 @@
 module xlsx;
 
-import std.file, std.xml, std.format, std.regex, std.conv, std.algorithm, std.range, std.utf;
+import std.file, std.format, std.regex, std.conv, std.algorithm, std.range, std.utf;
 import archive.core, archive.zip;
+
+import dxml.parser;
 
 private struct Coord {
     int row;
@@ -10,6 +12,8 @@ private struct Coord {
 
 /// Aliases a Sheet as a two-dimensional array of strings.
 alias Sheet = string[][];
+
+private enum configSplitYes = makeConfig(SplitEmpty.yes);
 
 /++
 Reads a sheet from an XLSX file. 
@@ -71,46 +75,63 @@ Sheet parseSheetXML(string xmlString, string[] sst) {
     Sheet temp;
     
     int cols = 0;
-    auto doc = new DocumentParser(xmlString);
-    doc.onEndTag["dimension"] = (in Element dim) {
-        auto dims = parseDimensions(dim.tag.attr["ref"]);
-        //temp ~= new string[dims.row];
-        cols = dims.column;
-    };
-    
-    doc.onStartTag["row"] = (ElementParser rowTag) {
-        //int r = parse!int(rowTag.tag.attr["r"])-1;
-        
-        auto theRow = new string[cols];
-        rowTag.onStartTag["c"] = (ElementParser cTag) {
-            Coord loc = parseLocation(cTag.tag.attr["r"]);
-            bool isRef = false;
-            if("t" in cTag.tag.attr)
-                isRef = cTag.tag.attr["t"] == "s";
-            
-            string val;
-            cTag.onEndTag["v"] = (in Element v) { val = v.text; };
-            cTag.parse();
 
-            if(isRef) {
-                int index = parse!int(val);
-                theRow[loc.column] = sst[index];
+    string[] theRow;
+
+    auto range = parseXML!configSplitYes(xmlString);
+    while(!range.empty) {
+        if(range.front.type == EntityType.elementStart) {
+            if(range.front.name == "dimension") {
+                auto attr = range.front.attributes.front;
+                assert(attr.name == "ref");
+                auto dims = parseDimensions(attr.value);
+                cols = dims.column;
+                assert(cols > 0);
             }
-            else {
-                theRow[loc.column] = val;
+            else if(range.front.name == "row") {
+                assert(cols > 0);
+                theRow = new string[cols];
             }
-        };
-        rowTag.parse();
-        temp ~= theRow;
-    };
-    doc.parse();
+            else if(range.front.name == "c") {
+                auto attrs = range.front.attributes;
+                Coord loc;
+                bool isref;
+                foreach(attr; attrs) {
+                    if(attr.name == "r") {
+                        loc = parseLocation(attr.value);
+                    }
+                    else if(attr.name == "t") {
+                        if(attr.value == "s") isref=true;
+                        else isref = false;
+                    }
+                }
+                assert(loc.row >= 0 && loc.column >= 0);
+                range.popFront;
+                range.popFront;
+                assert(range.front.type == EntityType.text);
+                string text = range.front.text;
+                assert(theRow.length > 0);
+                assert(loc.column < theRow.length);
+                if(isref) theRow[loc.column] = sst[parse!int(text)];
+                else theRow[loc.column] = text;
+            }
+        }
+        else if(range.front.type == EntityType.elementEnd) {
+            if(range.front.name == "row") {
+                temp ~= theRow;
+            }
+        }
+        range.popFront;
+    }
+    
+    
     return temp;
 }
 unittest {
     const string test = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="x14ac" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac"><dimension ref="A1:C3"/><sheetViews><sheetView tabSelected="1" workbookViewId="0"><selection activeCell="A4" sqref="A4"/></sheetView></sheetViews><sheetFormatPr defaultRowHeight="15" x14ac:dyDescent="0.25"/><sheetData><row r="1" spans="1:3" x14ac:dyDescent="0.25"><c r="A1"><v>1</v></c><c r="B1"><v>5</v></c><c r="C1"><v>7</v></c></row><row r="2" spans="1:3" x14ac:dyDescent="0.25"><c r="A2"><v>2</v></c><c r="B2"><v>4</v></c><c r="C2"><v>3</v></c></row><row r="3" spans="1:3" x14ac:dyDescent="0.25"><c r="A3"><v>7</v></c><c r="B3"><v>82</v></c><c r="C3"><v>1</v></c></row></sheetData><pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/></worksheet>`;
-    Sheet testSheet = [["1","5","7"],["2","4","3"],["7","82","1"]];
-    Sheet result = parseSheetXML(test, null);
+    const Sheet testSheet = [["1","5","7"],["2","4","3"],["7","82","1"]];
+    const Sheet result = parseSheetXML(test, null);
     assert(result == testSheet);
 }
 
@@ -127,20 +148,22 @@ Exceptions:
 Exception if the given sheet name is not in the workbook.
 +/
 private int getSheetId(string wbXml, string sheetName) {
-    int theId;
-    auto doc = new DocumentParser(wbXml);
-    doc.onEndTag["sheet"] = (in Element sheet) {
-        if(sheet.tag.attr["name"] == sheetName) {
-            string wat = sheet.tag.attr["sheetId"].dup;
-            theId = parse!int(wat);
-        }
-    };
-    doc.parse();
-
-    if(theId != 0) {
-        return theId;
+    auto range = parseXML!configSplitYes(wbXml);
+    while(!range.empty) {
+        if(range.front.type == EntityType.elementStart && range.front.name == "sheet") {
+            auto attrs = range.front.attributes;
+            bool nameFound;
+            foreach(attr; attrs) {
+                if(attr.name == "name" && attr.value == sheetName) nameFound = true;
+                else if(nameFound && attr.name == "sheetId") {
+                    return parse!int(attr.value);
+                }
+            }
+        } 
+        range.popFront;
     }
-    else throw new Exception("No sheet with that name!");
+    
+    throw new Exception("No sheet with that name!");
 }
 unittest {
     const string test = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -158,15 +181,18 @@ Returns:
 A simple string array that can be indexed into from an "s" type cell's value (which is a zero-based index, thankfully)
 +/
 private string[] parseStringTable(string sst) {
-    auto doc = new DocumentParser(sst);
+    //auto doc = new DocumentParser(sst);
     string[] table;
 
-    doc.onEndTag["t"] = (in Element t) {
-		table ~= t.text();
-    };
+    auto range = parseXML!configSplitYes(sst);
 
-    doc.parse();
-
+    while(!range.empty) {
+        if(range.front.type == EntityType.elementStart && range.front.name == "t") {
+            range.popFront;
+            table ~= range.front.text;
+        }
+        range.popFront;
+    }
     return table;
 }
 
@@ -197,8 +223,8 @@ private Coord parseLocation(string location) {
     return temp;
 }
 unittest {
-    Coord C3 = {2,2};
-    Coord B15 = {14,1};
+    const Coord C3 = {2,2};
+    const Coord B15 = {14,1};
     assert(parseLocation("C3") == C3);
     assert(parseLocation("B15") == B15);
 }
@@ -216,7 +242,7 @@ private Coord parseDimensions(string dims) {
 
 private int columnNameToNumber(string col) {
     reverse(col.dup);
-    int num = 0;
+    int num;
     foreach(i, c; col) {
         num += (c - 'A' + 1)*26^^i;
     }


### PR DESCRIPTION
Switch to using DXML for parsing XML, rather than std.xml. Testing with a 1024-row spreadsheet showed 56% speed improvement in debug builds and a 77% improvement in release (52 ms average became 12 ms).